### PR TITLE
chore: Fix deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,12 @@ jobs:
       - name: Install mdbook-linkcheck
         uses: taiki-e/install-action@mdbook-linkcheck
       - run: mdbook build
+      # Note: Using `mdbook-linkcheck` splits the `mdbook build` output into
+      # `html` and `linkcheck`, so we only deploy the former
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./book
+          path: ./book/html
           retention-days: 1
 
   deploy:

--- a/book.toml
+++ b/book.toml
@@ -10,3 +10,4 @@ git-repository-url = "https://github.com/argumentcomputer/user-manual"
 
 [output.linkcheck]
 follow-web-links = true
+optional = true


### PR DESCRIPTION
Deploys successfully at https://docs.argument.xyz

Temporarily enabled deploying on the `website branch` for testing. Will disable after merge