### PR TITLE
ci: Refactor deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,24 +7,24 @@ on:
       - main
 
 jobs:
-  test:
-    name: build and test
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install mdbook
-        uses: taiki-e/install-action@mdbook
-      - name: Install mdbook-linkcheck
-        uses: taiki-e/install-action@mdbook-linkcheck
+      - uses: taiki-e/install-action@mdbook
       - run: mdbook build
-      # Note: Using `mdbook-linkcheck` splits the `mdbook build` output into
-      # `html` and `linkcheck`, so we only deploy the former
-      - name: Upload artifact
+      - name: Upload build artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./book/html
+          path: ./book
           retention-days: 1
+
+  # Check links aren't broken
+  link-checker:
+    uses: argumentcomputer/ci-workflows/.github/workflows/links-check.yml@main
+    with: 
+      fail-fast: true
 
   deploy:
     if: github.ref_name == 'main' && github.event_name == 'push'
@@ -35,7 +35,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: test
+    needs: build
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/book.toml
+++ b/book.toml
@@ -7,7 +7,3 @@ title = "Lurk User Manual"
 
 [output.html]
 git-repository-url = "https://github.com/argumentcomputer/user-manual"
-
-[output.linkcheck]
-follow-web-links = true
-optional = true


### PR DESCRIPTION
Switches from [`mdbook-linkcheck`](https://github.com/Michael-F-Bryan/mdbook-linkcheck) to [`lychee`](https://github.com/lycheeverse/lychee), as the former prevents deployment if any links are broken.

The `link-checker` job is still expected fail for now, but deployment should work.